### PR TITLE
fix: prevent unread badge on self messages

### DIFF
--- a/web/src/components/ChatRoom.tsx
+++ b/web/src/components/ChatRoom.tsx
@@ -284,6 +284,15 @@ export const ChatRoom: React.FC<Props> = ({ room, isPrivateRoom, onRoomRemoved }
 
   const subject = roomToSubject(room, userInfo?.username || '');
 
+  // Keep MessageStore unread tracking aligned with the currently visible room.
+  useEffect(() => {
+    if (!client) return;
+    client.messages.setActiveRoom(room);
+    return () => {
+      client.messages.setActiveRoom(null);
+    };
+  }, [client, room]);
+
   // Join room and fetch history on mount
   useEffect(() => {
     if (!client || !connected) return;

--- a/web/src/lib/chat-client/MessageStore.ts
+++ b/web/src/lib/chat-client/MessageStore.ts
@@ -311,7 +311,7 @@ export class MessageStore extends TypedEmitter<MessageStoreEvents> {
     this.emit('message', roomKey, data);
 
     // Increment unread count if not the active room
-    if (roomKey !== this.activeRoom && data.user !== '__system__') {
+    if (roomKey !== this.activeRoom && data.user !== '__system__' && data.user !== this.username) {
       const newCount = (this.unreadCounts.get(roomKey) || 0) + 1;
       this.unreadCounts.set(roomKey, newCount);
 

--- a/web/src/lib/chat-client/__tests__/MessageStore.test.ts
+++ b/web/src/lib/chat-client/__tests__/MessageStore.test.ts
@@ -203,6 +203,19 @@ describe('MessageStore', () => {
       expect(store.getUnread('general').count).toBe(0);
     });
 
+    it('skips unread for own messages in inactive room', () => {
+      store.setActiveRoom('other-room');
+      const msg = makeMsg({ timestamp: 1000, user: 'alice', room: 'general' });
+
+      const unreadFn = vi.fn();
+      store.on('unreadChanged', unreadFn);
+
+      (store as any).processRoomChatMessage(msg, 'general');
+
+      expect(store.getUnread('general').count).toBe(0);
+      expect(unreadFn).not.toHaveBeenCalled();
+    });
+
     it('tracks mention counts', () => {
       store.setActiveRoom('other');
       const msg = makeMsg({ timestamp: 1000, user: 'bob', room: 'general', mentions: ['alice'] });


### PR DESCRIPTION
## Summary
- prevent unread increments for messages sent by the current user
- sync MessageStore active room in ChatRoom lifecycle
- add regression test for self-message unread behavior

## Test Plan
- npx vitest run web/src/lib/chat-client/__tests__/MessageStore.test.ts web/src/lib/chat-client/__tests__/RoomManager.test.ts
- docker compose up -d --build web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread message counter to exclude messages sent by the current user, preventing self-sent messages from inflating unread counts
  * Improved synchronization of unread message tracking with the currently active chat room for more accurate notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->