### PR TITLE
feat: scroll to unread separator when entering a room

### DIFF
--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -52,6 +52,8 @@ const LANG_OPTIONS = [
 export const MessageList: React.FC<Props> = React.memo(({ messages, currentUser, client, memberStatusMap, replyCounts, onReplyClick, onReadByClick, onEdit, onDelete, onReact, onTranslate, translations, translatingKeys, unreadAfterTs, onLoadMore, hasMore, loadingMore }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const unreadRef = useRef<HTMLDivElement>(null);
+  const initialScrollDoneRef = useRef(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [readByIndex, setReadByIndex] = useState<number | null>(null);
   const [readByUsers, setReadByUsers] = useState<Array<{userId: string; lastRead: number}>>([]);
@@ -81,9 +83,19 @@ export const MessageList: React.FC<Props> = React.memo(({ messages, currentUser,
     const prevFirstTs = prevFirstTsRef.current;
 
     if (prevFirstTs !== null && currentFirstTs < prevFirstTs) {
+      // Prepend (older messages loaded) — preserve scroll position
       const newScrollHeight = container.scrollHeight;
       container.scrollTop = newScrollHeight - prevScrollHeightRef.current;
+    } else if (!initialScrollDoneRef.current) {
+      // Initial load — scroll to unread separator or bottom
+      initialScrollDoneRef.current = true;
+      if (unreadRef.current) {
+        unreadRef.current.scrollIntoView({ block: 'center' });
+      } else {
+        bottomRef.current?.scrollIntoView();
+      }
     } else {
+      // New message appended — scroll to bottom
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
 
@@ -131,7 +143,7 @@ export const MessageList: React.FC<Props> = React.memo(({ messages, currentUser,
         return (
           <React.Fragment key={`${msg.timestamp}-${i}`}>
             {showUnreadSeparator && (
-              <div className="flex items-center gap-2 my-2">
+              <div ref={unreadRef} className="flex items-center gap-2 my-2">
                 <div className="flex-1 h-px bg-destructive" />
                 <span className="text-xs text-destructive font-semibold shrink-0">New</span>
                 <div className="flex-1 h-px bg-destructive" />


### PR DESCRIPTION
## Summary
On room entry, scroll to the unread separator (last seen position) instead of always scrolling to the bottom. If all messages are read, scrolls to bottom as before.

## Changes
- Add `unreadRef` on the unread separator div
- Add `initialScrollDoneRef` to distinguish initial load from new messages
- Initial load: `scrollIntoView({ block: 'center' })` on unread separator
- Subsequent messages: smooth scroll to bottom (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced message list scrolling behavior with intelligent scroll positioning logic based on message loading context
* Unread message separator now scrolls into view when initially loading messages
* Scroll position is preserved when loading older messages
* New appended messages trigger smooth scrolling to the bottom

<!-- end of auto-generated comment: release notes by coderabbit.ai -->