### PR TITLE
Add comprehensive alerting, SLO monitoring, and resource management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,6 +382,7 @@ services:
       VITE_KEYCLOAK_REALM: nats-chat
       VITE_KEYCLOAK_CLIENT_ID: nats-chat-app
       VITE_NATS_WS_URL: ws://localhost:9222
+      VITE_OTLP_ENDPOINT: http://localhost:4318
     depends_on:
       - keycloak
       - nats

--- a/k8s/base/app-registry-service/deployment.yaml
+++ b/k8s/base/app-registry-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: app-registry-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/auth-service/deployment.yaml
+++ b/k8s/base/auth-service/deployment.yaml
@@ -50,3 +50,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: auth-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/e2ee-key-service/deployment.yaml
+++ b/k8s/base/e2ee-key-service/deployment.yaml
@@ -29,3 +29,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: e2ee-key-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/fanout-service/deployment.yaml
+++ b/k8s/base/fanout-service/deployment.yaml
@@ -29,3 +29,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: fanout-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/k8s/base/grafana/alerts.yaml
+++ b/k8s/base/grafana/alerts.yaml
@@ -1,0 +1,814 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: grafana-default-email
+    receivers:
+      - uid: grafana-default-email
+        type: email
+        settings:
+          addresses: admin@localhost
+        disableResolveMessage: true
+  - orgId: 1
+    name: webhook-alerts
+    receivers:
+      - uid: webhook-alerts
+        type: webhook
+        settings:
+          url: ${ALERT_WEBHOOK_URL:-http://localhost:9095/alerts}
+          httpMethod: POST
+
+policies:
+  - orgId: 1
+    receiver: webhook-alerts
+    group_by:
+      - grafana_folder
+      - alertname
+    routes:
+      - receiver: webhook-alerts
+        matchers:
+          - severity = critical
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+      - receiver: webhook-alerts
+        matchers:
+          - severity = warning
+        group_wait: 1m
+        group_interval: 10m
+        repeat_interval: 12h
+
+groups:
+  - orgId: 1
+    name: service-health
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: service-down-auth
+        title: "ServiceDown: auth-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="auth-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "auth-service is down (no spans received in 5m)"
+
+      - uid: service-down-fanout
+        title: "ServiceDown: fanout-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="fanout-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "fanout-service is down (no spans received in 5m)"
+
+      - uid: service-down-room
+        title: "ServiceDown: room-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="room-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "room-service is down (no spans received in 5m)"
+
+      - uid: service-down-presence
+        title: "ServiceDown: presence-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="presence-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "presence-service is down (no spans received in 5m)"
+
+      - uid: service-down-persist
+        title: "ServiceDown: persist-worker"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="persist-worker"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "persist-worker is down (no spans received in 5m)"
+
+      - uid: service-down-history
+        title: "ServiceDown: history-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="history-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "history-service is down (no spans received in 5m)"
+
+      - uid: service-down-user-search
+        title: "ServiceDown: user-search-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="user-search-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "user-search-service is down (no spans received in 5m)"
+
+      - uid: service-down-translation
+        title: "ServiceDown: translation-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="translation-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "translation-service is down (no spans received in 5m)"
+
+      - uid: service-down-sticker
+        title: "ServiceDown: sticker-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="sticker-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "sticker-service is down (no spans received in 5m)"
+
+      - uid: service-down-app-registry
+        title: "ServiceDown: app-registry-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="app-registry-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "app-registry-service is down (no spans received in 5m)"
+
+      - uid: service-down-poll
+        title: "ServiceDown: poll-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="poll-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "poll-service is down (no spans received in 5m)"
+
+      - uid: service-down-kb
+        title: "ServiceDown: kb-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="kb-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "kb-service is down (no spans received in 5m)"
+
+  - orgId: 1
+    name: error-rates
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: high-error-rate
+        title: "High Error Rate"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: service:error_ratio:5m
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0.05
+              refId: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate exceeds 5% for a service"
+
+      - uid: persist-worker-errors
+        title: "Persist Worker Errors"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(messages_persist_errors_total[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 5
+              refId: C
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Persist worker has more than 5 errors in 5 minutes"
+
+      - uid: auth-rejection-spike
+        title: "Auth Rejection Spike"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: |
+                (
+                  sum(rate(auth_requests_total{result="rejected"}[5m]))
+                  /
+                  sum(rate(auth_requests_total[5m]))
+                )
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0.20
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Auth rejection rate exceeds 20%"
+
+  - orgId: 1
+    name: latency
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: slow-requests
+        title: "Slow Requests"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: service:p95_latency:5m
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 2
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 request latency exceeds 2 seconds"
+
+      - uid: high-fanout-latency
+        title: "High Fanout Latency"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.95, sum by (le) (rate(fanout_duration_seconds_bucket[5m])))
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0.5
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Fanout P95 latency exceeds 500ms"
+
+  - orgId: 1
+    name: slo-burn-rates
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: slo-message-delivery-burn-fast
+        title: "SLO Burn: Message Delivery (fast)"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: service:error_ratio:5m{service_name="fanout-service"} > (14.4 * 0.001)
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_1h > (14.4 * 0.001)
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+          slo: message-delivery
+        annotations:
+          summary: "Message delivery SLO (99.9%) burning error budget 14.4x faster than sustainable"
+
+      - uid: slo-message-delivery-burn-slow
+        title: "SLO Burn: Message Delivery (slow)"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_1h > (3 * 0.001)
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 21600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_6h > (3 * 0.001)
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 21600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 15m
+        labels:
+          severity: warning
+          slo: message-delivery
+        annotations:
+          summary: "Message delivery SLO (99.9%) burning error budget 3x faster than sustainable"
+
+      - uid: slo-fanout-latency-burn
+        title: "SLO Burn: Fanout Latency"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: service:p99_latency:5m{service_name="fanout-service"} > 0.200
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:fanout_latency:p99_1h > 0.200
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+          slo: fanout-latency
+        annotations:
+          summary: "Fanout P99 latency exceeds 200ms SLO target"
+
+  - orgId: 1
+    name: infrastructure
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: nats-slow-consumers
+        title: "NATS Slow Consumers"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(gnatsd_varz_slow_consumers[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0
+              refId: C
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NATS has slow consumers — messages may be dropping"
+
+      - uid: postgres-connection-saturation
+        title: "PostgreSQL Connection Saturation"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: |
+                sum(db_sql_connections_open)
+                /
+                sum(db_sql_connections_max_open)
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0.8
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL connection pool >80% utilized"

--- a/k8s/base/grafana/configmap.yaml
+++ b/k8s/base/grafana/configmap.yaml
@@ -54,20 +54,3 @@ data:
         options:
           path: /etc/grafana/provisioning/dashboards
           foldersFromFilesStructure: false
-  alerts.yaml: |
-    apiVersion: 1
-    contactPoints:
-      - orgId: 1
-        name: webhook-alerts
-        receivers:
-          - uid: webhook-alerts
-            type: webhook
-            settings:
-              url: ${ALERT_WEBHOOK_URL:-http://localhost:9095/alerts}
-              httpMethod: POST
-    policies:
-      - orgId: 1
-        receiver: webhook-alerts
-        group_by:
-          - grafana_folder
-          - alertname

--- a/k8s/base/grafana/configmap.yaml
+++ b/k8s/base/grafana/configmap.yaml
@@ -54,3 +54,20 @@ data:
         options:
           path: /etc/grafana/provisioning/dashboards
           foldersFromFilesStructure: false
+  alerts.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: webhook-alerts
+        receivers:
+          - uid: webhook-alerts
+            type: webhook
+            settings:
+              url: ${ALERT_WEBHOOK_URL:-http://localhost:9095/alerts}
+              httpMethod: POST
+    policies:
+      - orgId: 1
+        receiver: webhook-alerts
+        group_by:
+          - grafana_folder
+          - alertname

--- a/k8s/base/grafana/deployment.yaml
+++ b/k8s/base/grafana/deployment.yaml
@@ -60,8 +60,7 @@ spec:
               subPath: dashboards.yaml
               readOnly: true
             - name: provisioning-alerting
-              mountPath: /etc/grafana/provisioning/alerting/alerts.yaml
-              subPath: alerts.yaml
+              mountPath: /etc/grafana/provisioning/alerting
               readOnly: true
             - name: grafana-data
               mountPath: /var/lib/grafana
@@ -74,7 +73,7 @@ spec:
             name: grafana-provisioning
         - name: provisioning-alerting
           configMap:
-            name: grafana-provisioning
+            name: grafana-alerting
         - name: grafana-data
           persistentVolumeClaim:
             claimName: grafana-data

--- a/k8s/base/grafana/deployment.yaml
+++ b/k8s/base/grafana/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:latest
+          image: grafana/grafana:11.5.2
           ports:
             - containerPort: 3000
               name: http
@@ -31,6 +31,25 @@ spec:
               value: Admin
             - name: GF_SERVER_ROOT_URL
               value: "http://localhost:30001/"
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: provisioning-datasources
               mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
@@ -39,6 +58,10 @@ spec:
             - name: provisioning-dashboards
               mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
               subPath: dashboards.yaml
+              readOnly: true
+            - name: provisioning-alerting
+              mountPath: /etc/grafana/provisioning/alerting/alerts.yaml
+              subPath: alerts.yaml
               readOnly: true
             - name: grafana-data
               mountPath: /var/lib/grafana
@@ -49,5 +72,21 @@ spec:
         - name: provisioning-dashboards
           configMap:
             name: grafana-provisioning
+        - name: provisioning-alerting
+          configMap:
+            name: grafana-provisioning
         - name: grafana-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: grafana-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  labels:
+    app: grafana
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/base/history-service/deployment.yaml
+++ b/k8s/base/history-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: history-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/kb-app/deployment.yaml
+++ b/k8s/base/kb-app/deployment.yaml
@@ -21,3 +21,10 @@ spec:
           ports:
             - containerPort: 8093
               name: http
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/k8s/base/kb-service/deployment.yaml
+++ b/k8s/base/kb-service/deployment.yaml
@@ -41,3 +41,10 @@ spec:
               value: http://otel-collector:4318
             - name: OTEL_SERVICE_NAME
               value: kb-service
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/base/keycloak/deployment.yaml
+++ b/k8s/base/keycloak/deployment.yaml
@@ -36,6 +36,13 @@ spec:
             - name: realm-config
               mountPath: /opt/keycloak/data/import
               readOnly: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           readinessProbe:
             httpGet:
               path: /health/ready

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -82,3 +82,8 @@ configMapGenerator:
       - keycloak/realm-export.json
     options:
       disableNameSuffixHash: true
+  - name: grafana-alerting
+    files:
+      - alerts.yaml=grafana/alerts.yaml
+    options:
+      disableNameSuffixHash: true

--- a/k8s/base/loki/statefulset.yaml
+++ b/k8s/base/loki/statefulset.yaml
@@ -16,14 +16,35 @@ spec:
         app: loki
     spec:
       securityContext:
-        runAsUser: 0
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       containers:
         - name: loki
-          image: grafana/loki:latest
+          image: grafana/loki:3.4.2
           args: ["-config.file=/etc/loki/loki.yaml"]
           ports:
             - containerPort: 3100
               name: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /etc/loki

--- a/k8s/base/nats/statefulset.yaml
+++ b/k8s/base/nats/statefulset.yaml
@@ -32,6 +32,13 @@ spec:
               readOnly: true
             - name: jetstream-data
               mountPath: /data/jetstream
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           readinessProbe:
             httpGet:
               path: /healthz

--- a/k8s/base/otel-collector/deployment.yaml
+++ b/k8s/base/otel-collector/deployment.yaml
@@ -16,13 +16,34 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:latest
+          image: otel/opentelemetry-collector-contrib:0.118.0
           args: ["--config=/etc/otel/config.yaml"]
           ports:
             - containerPort: 4317
               name: otlp-grpc
             - containerPort: 4318
               name: otlp-http
+            - containerPort: 13133
+              name: health
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: config
               mountPath: /etc/otel

--- a/k8s/base/persist-worker/deployment.yaml
+++ b/k8s/base/persist-worker/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: persist-worker
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/poll-app/deployment.yaml
+++ b/k8s/base/poll-app/deployment.yaml
@@ -21,3 +21,10 @@ spec:
           ports:
             - containerPort: 8091
               name: http
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/k8s/base/poll-service/deployment.yaml
+++ b/k8s/base/poll-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: poll-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/postgres/statefulset.yaml
+++ b/k8s/base/postgres/statefulset.yaml
@@ -37,6 +37,13 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "chat", "-d", "chatdb"]

--- a/k8s/base/presence-service/deployment.yaml
+++ b/k8s/base/presence-service/deployment.yaml
@@ -29,3 +29,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: presence-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/prometheus/configmap.yaml
+++ b/k8s/base/prometheus/configmap.yaml
@@ -9,3 +9,78 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
+
+    rule_files:
+      - /etc/prometheus/recording-rules.yaml
+
+    scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 15s
+        static_configs:
+          - targets: ['otel-collector:8888']
+
+      - job_name: tempo
+        scrape_interval: 15s
+        static_configs:
+          - targets: ['tempo:3200']
+
+      - job_name: loki
+        scrape_interval: 15s
+        static_configs:
+          - targets: ['loki:3100']
+
+      - job_name: prometheus
+        scrape_interval: 15s
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: nats
+        scrape_interval: 15s
+        metrics_path: /metrics
+        static_configs:
+          - targets: ['nats:8222']
+
+      - job_name: keycloak
+        scrape_interval: 30s
+        metrics_path: /metrics
+        static_configs:
+          - targets: ['keycloak:9000']
+
+  recording-rules.yaml: |
+    groups:
+      - name: service_metrics
+        interval: 30s
+        rules:
+          - record: service:request_rate:5m
+            expr: sum by (service_name) (rate(traces_spanmetrics_calls_total[5m]))
+          - record: service:error_rate:5m
+            expr: sum by (service_name) (rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR"}[5m]))
+          - record: service:error_ratio:5m
+            expr: |
+              sum by (service_name) (rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR"}[5m]))
+              /
+              sum by (service_name) (rate(traces_spanmetrics_calls_total[5m]))
+          - record: service:p50_latency:5m
+            expr: histogram_quantile(0.50, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
+          - record: service:p95_latency:5m
+            expr: histogram_quantile(0.95, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
+          - record: service:p99_latency:5m
+            expr: histogram_quantile(0.99, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
+
+      - name: slo_burn_rates
+        interval: 30s
+        rules:
+          - record: slo:message_delivery:error_ratio_5m
+            expr: |
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[5m]))
+              /
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[5m]))
+          - record: slo:message_delivery:error_ratio_1h
+            expr: |
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[1h]))
+              /
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[1h]))
+          - record: slo:fanout_latency:p99_5m
+            expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[5m])))
+          - record: slo:fanout_latency:p99_1h
+            expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[1h])))

--- a/k8s/base/prometheus/configmap.yaml
+++ b/k8s/base/prometheus/configmap.yaml
@@ -70,17 +70,25 @@ data:
       - name: slo_burn_rates
         interval: 30s
         rules:
-          - record: slo:message_delivery:error_ratio_5m
-            expr: |
-              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[5m]))
-              /
-              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[5m]))
           - record: slo:message_delivery:error_ratio_1h
             expr: |
               sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[1h]))
               /
               sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[1h]))
-          - record: slo:fanout_latency:p99_5m
-            expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[5m])))
+          - record: slo:message_delivery:error_ratio_6h
+            expr: |
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[6h]))
+              /
+              sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[6h]))
+          - record: slo:auth:error_ratio_1h
+            expr: |
+              sum(rate(traces_spanmetrics_calls_total{service_name="auth-service", status_code="STATUS_CODE_ERROR"}[1h]))
+              /
+              sum(rate(traces_spanmetrics_calls_total{service_name="auth-service"}[1h]))
           - record: slo:fanout_latency:p99_1h
             expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[1h])))
+          - record: slo:persist:error_ratio_1h
+            expr: |
+              sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker", status_code="STATUS_CODE_ERROR"}[1h]))
+              /
+              sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker"}[1h]))

--- a/k8s/base/prometheus/statefulset.yaml
+++ b/k8s/base/prometheus/statefulset.yaml
@@ -17,14 +17,34 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:latest
+          image: prom/prometheus:v3.2.1
           args:
             - "--config.file=/etc/prometheus/prometheus.yaml"
             - "--web.enable-remote-write-receiver"
             - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=30d"
           ports:
             - containerPort: 9090
               name: http
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus

--- a/k8s/base/read-receipt-service/deployment.yaml
+++ b/k8s/base/read-receipt-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: read-receipt-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/room-service/deployment.yaml
+++ b/k8s/base/room-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: room-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/sticker-images/deployment.yaml
+++ b/k8s/base/sticker-images/deployment.yaml
@@ -21,6 +21,13 @@ spec:
           ports:
             - containerPort: 8090
               name: http
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           readinessProbe:
             httpGet:
               path: /health

--- a/k8s/base/sticker-service/deployment.yaml
+++ b/k8s/base/sticker-service/deployment.yaml
@@ -36,3 +36,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: sticker-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/tempo/configmap.yaml
+++ b/k8s/base/tempo/configmap.yaml
@@ -26,7 +26,7 @@ data:
 
     compactor:
       compaction:
-        block_retention: 168h
+        block_retention: 720h
 
     metrics_generator:
       registry:

--- a/k8s/base/tempo/statefulset.yaml
+++ b/k8s/base/tempo/statefulset.yaml
@@ -60,4 +60,4 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 5Gi
+            storage: 15Gi

--- a/k8s/base/tempo/statefulset.yaml
+++ b/k8s/base/tempo/statefulset.yaml
@@ -24,6 +24,25 @@ spec:
               name: http
             - containerPort: 4318
               name: otlp-http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3200
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3200
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /etc/tempo

--- a/k8s/base/translation-service/deployment.yaml
+++ b/k8s/base/translation-service/deployment.yaml
@@ -31,3 +31,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: translation-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/user-search-service/deployment.yaml
+++ b/k8s/base/user-search-service/deployment.yaml
@@ -43,3 +43,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: user-search-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/base/web/configmap.yaml
+++ b/k8s/base/web/configmap.yaml
@@ -10,5 +10,6 @@ data:
       VITE_KEYCLOAK_URL: "http://keycloak:8080",
       VITE_KEYCLOAK_REALM: "nats-chat",
       VITE_KEYCLOAK_CLIENT_ID: "nats-chat-app",
-      VITE_NATS_WS_URL: "ws://nats:9222"
+      VITE_NATS_WS_URL: "ws://nats:9222",
+      VITE_OTLP_ENDPOINT: "/otlp"
     };

--- a/k8s/base/web/deployment.yaml
+++ b/k8s/base/web/deployment.yaml
@@ -26,6 +26,13 @@ spec:
               mountPath: /usr/share/nginx/html/env.js
               subPath: env.js
               readOnly: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           readinessProbe:
             httpGet:
               path: /

--- a/k8s/base/whiteboard-app/deployment.yaml
+++ b/k8s/base/whiteboard-app/deployment.yaml
@@ -21,3 +21,10 @@ spec:
           ports:
             - containerPort: 8092
               name: http
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/k8s/base/whiteboard-service/deployment.yaml
+++ b/k8s/base/whiteboard-service/deployment.yaml
@@ -34,3 +34,10 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: whiteboard-service
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/k8s/overlays/cloud/ingress.yaml
+++ b/k8s/overlays/cloud/ingress.yaml
@@ -17,13 +17,6 @@ spec:
     - host: chat.cowbay.wtf
       http:
         paths:
-          - path: /otlp
-            pathType: Prefix
-            backend:
-              service:
-                name: otel-collector
-                port:
-                  number: 4318
           - path: /
             pathType: Prefix
             backend:
@@ -31,3 +24,29 @@ spec:
                 name: web
                 port:
                   number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nats-chat-otlp-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/limit-rps: "50"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - chat.cowbay.wtf
+      secretName: nats-chat-tls
+  rules:
+    - host: chat.cowbay.wtf
+      http:
+        paths:
+          - path: /otlp
+            pathType: Prefix
+            backend:
+              service:
+                name: otel-collector
+                port:
+                  number: 4318

--- a/k8s/overlays/cloud/ingress.yaml
+++ b/k8s/overlays/cloud/ingress.yaml
@@ -17,6 +17,13 @@ spec:
     - host: chat.cowbay.wtf
       http:
         paths:
+          - path: /otlp
+            pathType: Prefix
+            backend:
+              service:
+                name: otel-collector
+                port:
+                  number: 4318
           - path: /
             pathType: Prefix
             backend:

--- a/k8s/overlays/local/ingress.yaml
+++ b/k8s/overlays/local/ingress.yaml
@@ -17,6 +17,13 @@ spec:
     - host: chat.cowbay.wtf
       http:
         paths:
+          - path: /otlp
+            pathType: Prefix
+            backend:
+              service:
+                name: otel-collector
+                port:
+                  number: 4318
           - path: /
             pathType: Prefix
             backend:

--- a/k8s/overlays/local/patches/web-env.yaml
+++ b/k8s/overlays/local/patches/web-env.yaml
@@ -8,5 +8,6 @@ data:
       VITE_KEYCLOAK_URL: window.location.origin + "/auth",
       VITE_KEYCLOAK_REALM: "nats-chat",
       VITE_KEYCLOAK_CLIENT_ID: "nats-chat-app",
-      VITE_NATS_WS_URL: (window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host + "/nats-ws"
+      VITE_NATS_WS_URL: (window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host + "/nats-ws",
+      VITE_OTLP_ENDPOINT: window.location.origin + "/otlp"
     };

--- a/observability/grafana/provisioning/alerting/alerts.yaml
+++ b/observability/grafana/provisioning/alerting/alerts.yaml
@@ -455,12 +455,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: |
-                (
-                  sum by (service_name) (rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR"}[5m]))
-                  /
-                  sum by (service_name) (rate(traces_spanmetrics_calls_total[5m]))
-                )
+              expr: service:error_ratio:5m
               instant: true
               refId: A
           - refId: C
@@ -569,7 +564,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: histogram_quantile(0.95, sum by (le, service_name) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
+              expr: service:p95_latency:5m
               instant: true
               refId: A
           - refId: C
@@ -640,7 +635,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: slo:message_delivery:error_ratio_5m > (14.4 * 0.001)
+              expr: service:error_ratio:5m{service_name="fanout-service"} > (14.4 * 0.001)
               instant: true
               refId: A
           - refId: B
@@ -716,7 +711,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: slo:fanout_latency:p99_5m > 0.200
+              expr: service:p99_latency:5m{service_name="fanout-service"} > 0.200
               instant: true
               refId: A
           - refId: B
@@ -795,7 +790,7 @@ groups:
               expr: |
                 sum(db_sql_connections_open)
                 /
-                sum(db_sql_connections_max_open) > 0.8
+                sum(db_sql_connections_max_open)
               instant: true
               refId: A
           - refId: C
@@ -810,7 +805,7 @@ groups:
                 - evaluator:
                     type: gt
                     params:
-                      - 0
+                      - 0.8
               refId: C
         for: 5m
         labels:

--- a/observability/grafana/provisioning/alerting/alerts.yaml
+++ b/observability/grafana/provisioning/alerting/alerts.yaml
@@ -9,13 +9,34 @@ contactPoints:
         settings:
           addresses: admin@localhost
         disableResolveMessage: true
+  - orgId: 1
+    name: webhook-alerts
+    receivers:
+      - uid: webhook-alerts
+        type: webhook
+        settings:
+          url: ${ALERT_WEBHOOK_URL:-http://localhost:9095/alerts}
+          httpMethod: POST
 
 policies:
   - orgId: 1
-    receiver: grafana-default-email
+    receiver: webhook-alerts
     group_by:
       - grafana_folder
       - alertname
+    routes:
+      - receiver: webhook-alerts
+        matchers:
+          - severity = critical
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+      - receiver: webhook-alerts
+        matchers:
+          - severity = warning
+        group_wait: 1m
+        group_interval: 10m
+        repeat_interval: 12h
 
 groups:
   - orgId: 1
@@ -221,6 +242,204 @@ groups:
         annotations:
           summary: "history-service is down (no spans received in 5m)"
 
+      - uid: service-down-user-search
+        title: "ServiceDown: user-search-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="user-search-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "user-search-service is down (no spans received in 5m)"
+
+      - uid: service-down-translation
+        title: "ServiceDown: translation-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="translation-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "translation-service is down (no spans received in 5m)"
+
+      - uid: service-down-sticker
+        title: "ServiceDown: sticker-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="sticker-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "sticker-service is down (no spans received in 5m)"
+
+      - uid: service-down-app-registry
+        title: "ServiceDown: app-registry-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="app-registry-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "app-registry-service is down (no spans received in 5m)"
+
+      - uid: service-down-poll
+        title: "ServiceDown: poll-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="poll-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "poll-service is down (no spans received in 5m)"
+
+      - uid: service-down-kb
+        title: "ServiceDown: kb-service"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(traces_spanmetrics_calls_total{service_name="kb-service"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 0.001
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "kb-service is down (no spans received in 5m)"
+
   - orgId: 1
     name: error-rates
     folder: Alerts
@@ -405,3 +624,196 @@ groups:
           severity: warning
         annotations:
           summary: "Fanout P95 latency exceeds 500ms"
+
+  - orgId: 1
+    name: slo-burn-rates
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: slo-message-delivery-burn-fast
+        title: "SLO Burn: Message Delivery (fast)"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_5m > (14.4 * 0.001)
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_1h > (14.4 * 0.001)
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 2m
+        labels:
+          severity: critical
+          slo: message-delivery
+        annotations:
+          summary: "Message delivery SLO (99.9%) burning error budget 14.4x faster than sustainable"
+
+      - uid: slo-message-delivery-burn-slow
+        title: "SLO Burn: Message Delivery (slow)"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_1h > (3 * 0.001)
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 21600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:message_delivery:error_ratio_6h > (3 * 0.001)
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 21600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 15m
+        labels:
+          severity: warning
+          slo: message-delivery
+        annotations:
+          summary: "Message delivery SLO (99.9%) burning error budget 3x faster than sustainable"
+
+      - uid: slo-fanout-latency-burn
+        title: "SLO Burn: Fanout Latency"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:fanout_latency:p99_5m > 0.200
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: slo:fanout_latency:p99_1h > 0.200
+              instant: true
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 3600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: "$A > 0 && $B > 0"
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+          slo: fanout-latency
+        annotations:
+          summary: "Fanout P99 latency exceeds 200ms SLO target"
+
+  - orgId: 1
+    name: infrastructure
+    folder: Alerts
+    interval: 30s
+    rules:
+      - uid: nats-slow-consumers
+        title: "NATS Slow Consumers"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: increase(gnatsd_varz_slow_consumers[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0
+              refId: C
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NATS has slow consumers — messages may be dropping"
+
+      - uid: postgres-connection-saturation
+        title: "PostgreSQL Connection Saturation"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: |
+                sum(db_sql_connections_open)
+                /
+                sum(db_sql_connections_max_open) > 0.8
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL connection pool >80% utilized"

--- a/observability/prometheus/prometheus.yaml
+++ b/observability/prometheus/prometheus.yaml
@@ -25,3 +25,17 @@ scrape_configs:
     scrape_interval: 15s
     static_configs:
       - targets: ['localhost:9090']
+
+  # NATS server monitoring metrics
+  - job_name: nats
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['nats:8222']
+
+  # Keycloak metrics (Micrometer)
+  - job_name: keycloak
+    scrape_interval: 30s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['keycloak:9000']

--- a/observability/prometheus/prometheus.yaml
+++ b/observability/prometheus/prometheus.yaml
@@ -26,14 +26,12 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  # NATS server monitoring metrics
   - job_name: nats
     scrape_interval: 15s
     metrics_path: /metrics
     static_configs:
       - targets: ['nats:8222']
 
-  # Keycloak metrics (Micrometer)
   - job_name: keycloak
     scrape_interval: 30s
     metrics_path: /metrics

--- a/observability/prometheus/recording-rules.yaml
+++ b/observability/prometheus/recording-rules.yaml
@@ -18,16 +18,9 @@ groups:
       - record: service:p99_latency:5m
         expr: histogram_quantile(0.99, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
 
-  # SLO burn-rate rules for message delivery (99.9% success target)
   - name: slo_burn_rates
     interval: 30s
     rules:
-      # Message delivery SLO: 99.9% success rate
-      - record: slo:message_delivery:error_ratio_5m
-        expr: |
-          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[5m]))
-          /
-          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[5m]))
       - record: slo:message_delivery:error_ratio_1h
         expr: |
           sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[1h]))
@@ -38,31 +31,13 @@ groups:
           sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[6h]))
           /
           sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[6h]))
-
-      # Auth SLO: 99.9% success rate
-      - record: slo:auth:error_ratio_5m
-        expr: |
-          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service", status_code="STATUS_CODE_ERROR"}[5m]))
-          /
-          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service"}[5m]))
       - record: slo:auth:error_ratio_1h
         expr: |
           sum(rate(traces_spanmetrics_calls_total{service_name="auth-service", status_code="STATUS_CODE_ERROR"}[1h]))
           /
           sum(rate(traces_spanmetrics_calls_total{service_name="auth-service"}[1h]))
-
-      # Fanout latency SLO: P99 < 200ms
-      - record: slo:fanout_latency:p99_5m
-        expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[5m])))
       - record: slo:fanout_latency:p99_1h
         expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[1h])))
-
-      # Persist worker SLO: 99.9% success rate
-      - record: slo:persist:error_ratio_5m
-        expr: |
-          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker", status_code="STATUS_CODE_ERROR"}[5m]))
-          /
-          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker"}[5m]))
       - record: slo:persist:error_ratio_1h
         expr: |
           sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker", status_code="STATUS_CODE_ERROR"}[1h]))

--- a/observability/prometheus/recording-rules.yaml
+++ b/observability/prometheus/recording-rules.yaml
@@ -17,3 +17,54 @@ groups:
         expr: histogram_quantile(0.95, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
       - record: service:p99_latency:5m
         expr: histogram_quantile(0.99, sum by (service_name, le) (rate(traces_spanmetrics_duration_seconds_bucket[5m])))
+
+  # SLO burn-rate rules for message delivery (99.9% success target)
+  - name: slo_burn_rates
+    interval: 30s
+    rules:
+      # Message delivery SLO: 99.9% success rate
+      - record: slo:message_delivery:error_ratio_5m
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[5m]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[5m]))
+      - record: slo:message_delivery:error_ratio_1h
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[1h]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[1h]))
+      - record: slo:message_delivery:error_ratio_6h
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service", status_code="STATUS_CODE_ERROR"}[6h]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="fanout-service"}[6h]))
+
+      # Auth SLO: 99.9% success rate
+      - record: slo:auth:error_ratio_5m
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service", status_code="STATUS_CODE_ERROR"}[5m]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service"}[5m]))
+      - record: slo:auth:error_ratio_1h
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service", status_code="STATUS_CODE_ERROR"}[1h]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="auth-service"}[1h]))
+
+      # Fanout latency SLO: P99 < 200ms
+      - record: slo:fanout_latency:p99_5m
+        expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[5m])))
+      - record: slo:fanout_latency:p99_1h
+        expr: histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_duration_seconds_bucket{service_name="fanout-service"}[1h])))
+
+      # Persist worker SLO: 99.9% success rate
+      - record: slo:persist:error_ratio_5m
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker", status_code="STATUS_CODE_ERROR"}[5m]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker"}[5m]))
+      - record: slo:persist:error_ratio_1h
+        expr: |
+          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker", status_code="STATUS_CODE_ERROR"}[1h]))
+          /
+          sum(rate(traces_spanmetrics_calls_total{service_name="persist-worker"}[1h]))

--- a/observability/tempo/tempo.yaml
+++ b/observability/tempo/tempo.yaml
@@ -18,7 +18,7 @@ storage:
 
 compactor:
   compaction:
-    block_retention: 168h
+    block_retention: 720h
 
 metrics_generator:
   registry:

--- a/pkg/otelhelper/otel.go
+++ b/pkg/otelhelper/otel.go
@@ -95,7 +95,6 @@ func Init(ctx context.Context) (Shutdown, error) {
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(traceExporter),
 		sdktrace.WithResource(res),
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
 	)
 	otel.SetTracerProvider(tp)
 

--- a/pkg/otelhelper/otel.go
+++ b/pkg/otelhelper/otel.go
@@ -95,6 +95,7 @@ func Init(ctx context.Context) (Shutdown, error) {
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(traceExporter),
 		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
 	)
 	otel.SetTracerProvider(tp)
 


### PR DESCRIPTION
## Summary
This PR introduces comprehensive Grafana alerting rules, SLO burn rate monitoring, Prometheus recording rules, and resource requests/limits across all Kubernetes deployments. It also updates container images to specific versions and adds health checks to critical services.

## Key Changes

### Alerting & Monitoring
- **New Grafana alerts configuration** (`k8s/base/grafana/alerts.yaml`): 814-line comprehensive alert rules covering:
  - Service health monitoring (12 services with down detection)
  - Error rate tracking (high error rates, persist worker errors, auth rejection spikes)
  - Latency monitoring (slow requests, fanout latency)
  - SLO burn rate alerts (message delivery and fanout latency SLOs)
  - Infrastructure alerts (NATS slow consumers, PostgreSQL issues)
- **Webhook-based alert routing**: Added webhook contact point with configurable URL (`ALERT_WEBHOOK_URL`) for alert delivery
- **Alert routing policies**: Implemented severity-based routing with different group intervals and repeat intervals for critical vs warning alerts

### Recording Rules & Metrics
- **Prometheus recording rules**: Added service-level metrics aggregation:
  - `service:request_rate:5m`, `service:error_rate:5m`, `service:error_ratio:5m`
  - `service:p50_latency:5m`, `service:p95_latency:5m`, `service:p99_latency:5m`
  - SLO burn rate calculations for message delivery and fanout latency
- **Simplified alert expressions**: Updated alert rules to use recording rules instead of complex inline queries
- **Prometheus configuration**: Added scrape configs for NATS, Keycloak, and other infrastructure components

### Resource Management
- **Resource requests/limits** added to all service deployments:
  - Core services (auth, fanout, room, etc.): 50m CPU, 64Mi memory requests
  - Infrastructure (Prometheus, Loki, Tempo, Grafana): 50-500m CPU, 128Mi-512Mi memory
  - Web/UI services: 25m CPU, 32Mi memory requests
  - Database (PostgreSQL): 100m CPU, 256Mi memory
- **Health checks** added to critical services:
  - Readiness/liveness probes for Grafana, Prometheus, Tempo, Loki, OTEL Collector
  - Proper initial delays and periods for probe configuration

### Container Image Updates
- Grafana: `latest` → `11.5.2`
- Prometheus: `latest` → `v3.2.1`
- Loki: `latest` → `3.4.2`
- OTEL Collector: `latest` → `0.118.0`
- Tempo: Retained with added health checks

### Infrastructure Improvements
- **Tempo retention**: Increased block retention from 168h (7 days) to 720h (30 days)
- **Prometheus retention**: Added 30-day retention policy
- **Loki security**: Updated to run as non-root user (10001:10001)
- **OTLP ingress**: Added OTLP endpoint routing in cloud overlay with rate limiting
- **Frontend configuration**: Added `VITE_OTLP_ENDPOINT` environment variable for client-side telemetry

## Notable Implementation Details
- Alert rules use threshold-based conditions with configurable parameters
- SLO burn rate alerts implement multi-window evaluation (5m + 1h for fast burn, 30m + 6h for slow burn)
- Recording rules aggregate metrics by service_name for consistent querying across alerts
- All resource limits are conservative to support development/testing environments
- Health checks use appropriate paths and intervals for each service type

https://claude.ai/code/session_017VQ7qwaM9JrSjKSpj8jwgg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry (OTLP) integration for distributed tracing and metrics collection
  * Implemented comprehensive alerting system with critical, warning, and SLO burn-rate rules
  * Added SLO monitoring for key services including message delivery and fanout latency

* **Chores**
  * Pinned component versions (Grafana, Prometheus, Loki, Tempo) for stability
  * Configured resource limits and requests across all services for optimal scheduling
  * Extended data retention periods for trace and log storage
  * Added health checks and persistent storage for monitoring systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->